### PR TITLE
fix superstruct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "superstruct": "^0.6.2"
+    "superstruct": "0.6.2"
   }
 }


### PR DESCRIPTION
SE modifico la versión del package superstruct, exactamente para la versión 0.6.2 para evitar problemas al instalar las dependencias