### PR TITLE
URLs with spaces are now supported

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -35,7 +35,7 @@ const email = value => emailRegex.test(value);
  * @param {string} value - string to check
  * @returns {boolean}
  */
-const URL = value => urlRegex.test(value);
+const URL = value => urlRegex.test(encodeURI(value));
 
 /**
  * @function empty

--- a/tests/superstruct-test.js
+++ b/tests/superstruct-test.js
@@ -44,6 +44,7 @@ describe('Superstruct', () => {
 			Schema({ url: 'http://www.example.com' });
 			Schema({ url: 'http://www.example.com.ar' });
 			Schema({ url: 'https://www.example.com.ar' });
+			Schema({ url: 'https://www.example.com.ar/url with spaces' });
 		});
 
 		it('Should throw for non URL', () => {


### PR DESCRIPTION
Hay casos donde el cliente tiene imagenes de productos con espacios en la URL que son "validas" por decirlo de alguna forma pero hoy rompemos por la regexp que hay.